### PR TITLE
Updated approx_pos method in dataset.py

### DIFF
--- a/title_maker_pro/datasets.py
+++ b/title_maker_pro/datasets.py
@@ -337,17 +337,13 @@ class ParsedDictionaryDefinitionDataset(Dataset):
 
     @classmethod
     def approx_pos(cls, nlp, sentence, lookup_idx, lookup_len):
-        start_end_re = re.compile(r"start_char=(\d+)\|end_char=(\d+)")
         doc = nlp(sentence)
         uposes = Counter()
 
         for sentence in doc.sentences:
             for word in sentence.words:
-                m = start_end_re.match(word.misc)
-                if not m:
-                    raise RuntimeError("Unable to extract start and end positions!")
-                start_char = int(m.group(1))
-                end_char = int(m.group(2))
+                start_char = word.start_char
+                end_char = word.end_char
                 uposes[word.upos] += _len_range_overlap(
                     (lookup_idx, lookup_idx + lookup_len - 1), (start_char, end_char - 1)
                 )


### PR DESCRIPTION
Updated ParsedDictionaryDefinitionDataset approx_pos method in dataset.py.

Something must've changed in how a `stanza.models.common.doc.Word` is structured, causing the method `def approx_pos(cls, nlp, sentence, lookup_idx, lookup_len):` to fail.

The Word object now looks something like:
```json
{
  "id": 6,
  "text": "a",
  "upos": "DET",
  "xpos": "DT",
  "feats": "Definite=Ind|PronType=Art",
  "start_char": 23,
  "end_char": 24
}
```

The plus side of this is that the `start_char` and `end_char` can now be extracted without using regex.

I've tested the change in Google Colab.